### PR TITLE
update link to legacy install

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ By
 
 
 ## Installation (Tested on Ubuntu 16.04/18.04/Arch Linux. Windows/OS X not supported.)
- - Install [`taichi (legacy branch)`](https://taichi.readthedocs.io/en/latest/installation.html#ubuntu-arch-linux-and-mac-os-x) first and put this in the `projects` folder.
+ - Install [`taichi (legacy branch)`](https://taichi.readthedocs.io/en/stable/legacy_installation.html) first and put this in the `projects` folder.
  - Build the FEM solver: `cd solver && make` (Note: this needs Intel `icc` and `mkl`. Please install if you don't have it.)
  - Set the following environment variables according to your machine.
  For example,


### PR DESCRIPTION
[skip ci] updating the readme to link to the new location of taichi-legacy install